### PR TITLE
Restricted records generated to 9am and 5:30pm

### DIFF
--- a/app/Resource.php
+++ b/app/Resource.php
@@ -30,8 +30,9 @@ class Resource extends Model {
     public function withRecordsWithinDateRange(Carbon $startDate, Carbon $endDate)
     {
         return $this->whereId($this->id)->with(['records' => function ($record) use ($startDate, $endDate) {
-            $record->where('created_at', '>=', $startDate)
-                   ->where('created_at', '<=', $endDate)
+            $record->whereBetween('created_at', [$startDate->toDateString(), $endDate->toDateString()])
+                    ->whereRaw('TIME(created_at) >= ?', ['09:00:00'])
+                    ->whereRaw('TIME(created_at) <= ?', ['17:30:00'])
                    ->orderBy('created_at', 'desc');
         }])->first();
     }


### PR DESCRIPTION
Added restriction on resource records generated. Records are now generated from 09:00 to 17:30 