### PR TITLE
Users can specify time (start and end time) per resource. 

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -101,7 +101,7 @@ class ResourceController extends Controller
      */
     public function store(CreateRequest $request)
     {
-        Resource::create($request->only(['name', 'type']));
+        Resource::create($request->only(['name', 'type','resource_starts','resource_ends']));
 
         return redirect(route('resources.index'))->withSuccess('Resource created!');
     }
@@ -126,7 +126,8 @@ class ResourceController extends Controller
      */
     public function update(UpdateRequest $request, Resource $resource)
     {
-        $resource->update($request->only('name', 'type'));
+        // dd($request->all());
+        $resource->update($request->only('name', 'type','resource_starts','resource_ends'));
 
         return redirect(route('resources.show', $resource->id))->withSuccess('Updated successfully!');
     }

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -126,7 +126,6 @@ class ResourceController extends Controller
      */
     public function update(UpdateRequest $request, Resource $resource)
     {
-        // dd($request->all());
         $resource->update($request->only('name', 'type','resource_starts','resource_ends'));
 
         return redirect(route('resources.show', $resource->id))->withSuccess('Updated successfully!');

--- a/app/Resource.php
+++ b/app/Resource.php
@@ -18,7 +18,7 @@ class Resource extends Model {
     /**
      * {@inheritDoc}
      */
-    protected $fillable = ['name', 'type'];
+    protected $fillable = ['name', 'type','resource_starts','resource_ends'];
 
     /**
      * Get resource with records from date range.
@@ -29,22 +29,16 @@ class Resource extends Model {
      */
     public function withRecordsWithinDateRange(Carbon $startDate, Carbon $endDate)
     {
+        $resource_starts   = isset( $this->resource_starts) ?  $this->resource_starts : '00:00';
+        $resource_ends     = isset( $this->resource_ends) ?  $this->resource_ends : '24:00';
 
-        if ($this->id == "41a3fb40-67ea-11e7-b81f-416527528196" || $this->id == "d47b0330-67e2-11e7-b106-bfa264a5d130" ) {
-            return $this->whereId($this->id)->with(['records' => function ($record) use ($startDate, $endDate) {
-                $record->whereBetween('created_at', [$startDate->toDateString(), $endDate->addDay(1)->toDateString()])
-                        ->orderBy('created_at', 'desc');
-            }])->first();
-        }
-        else{
-            return $this->whereId($this->id)->with(['records' => function ($record) use ($startDate, $endDate) {
-                $record->whereBetween('created_at', [$startDate->toDateString(), $endDate->addDay(1)->toDateString()])
-                        ->whereRaw('TIME(created_at) >= ?', ['09:00:00'])
-                        ->whereRaw('TIME(created_at) <= ?', ['17:30:00'])
-                        ->orderBy('created_at', 'desc');
-            }])->first();
-            
-        }
+        return $this->whereId($this->id)->with(['records' => function ($record) use ($startDate, $endDate, $resource_starts, $resource_ends ) {
+            $record->whereBetween('created_at', [$startDate->toDateString(), $endDate->addDay(1)->toDateString()])
+                    ->whereRaw('TIME(created_at) >= ?', $resource_starts)
+                    ->whereRaw('TIME(created_at) <= ?', $resource_ends)
+                    ->orderBy('created_at', 'desc');
+        }])->first();      
+              
     }
 
     /**

--- a/database/migrations/2017_09_24_05183_add_resource_time_range.php
+++ b/database/migrations/2017_09_24_05183_add_resource_time_range.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddResourceTimeRange extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('resources', function ($table) {
+            $table->time('resource_starts')->after('type')->nullable();
+            $table->time('resource_ends')->after('resource_starts')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('resources', function (Blueprint $table){
+            $table->dropColumn('resource_starts');
+            $table->dropColumn('resource_ends');
+        });
+    }
+}
+
+

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,6 +14,7 @@
     <link href="https://fonts.googleapis.com/css?family=Passion+One|Raleway:300,400,600" rel="stylesheet">
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/css/bootstrap-datepicker.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/clockpicker/0.0.7/bootstrap-clockpicker.min.css">
 </head>
 <body>
     <div id="app">
@@ -80,6 +81,7 @@
     <!-- Scripts -->
     <script src="{{ asset('js/app.js') }}"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.7.1/js/bootstrap-datepicker.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/clockpicker/0.0.7/bootstrap-clockpicker.min.js"></script>
 
     <script type="text/javascript">
         $('.panel-body .input-daterange').datepicker({
@@ -89,6 +91,12 @@
             autoclose: true,
             endDate: new Date(),
             startDate: new Date(new Date().setFullYear(new Date().getFullYear() - 1)),
+        });
+        $('.clockpicker').clockpicker({
+            align: 'left',
+            donetext: 'Done',
+            autoclose:'true',
+            'default': 'now'
         });
     </script>
 

--- a/resources/views/resources/create.blade.php
+++ b/resources/views/resources/create.blade.php
@@ -31,6 +31,28 @@
                                 </select>
                             </div>
                         </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2" for="name">Report starts:</label>
+                            <div class="col-sm-10">
+                                <div class="input-group clockpicker">
+                                <input type="text" name="resource_starts" class="form-control" value="{{ old('resource_starts') }}">
+                                <span class="input-group-addon">
+                                    <span class="glyphicon glyphicon-time"></span>
+                                </span>
+                            </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2" for="name">Report ends:</label>
+                            <div class="col-sm-10">
+                                <div class="input-group clockpicker">
+                                <input type="text" name="resource_ends" class="form-control" value="{{old('resource_ends')}}">
+                                <span class="input-group-addon">
+                                    <span class="glyphicon glyphicon-time"></span>
+                                </span>
+                            </div>
+                            </div>
+                        </div>
                     </div>
                     <div class="panel-footer clearfix">
                         <button class="btn btn-md btn-primary pull-right" type="submit">Create Resource</button>

--- a/resources/views/resources/edit.blade.php
+++ b/resources/views/resources/edit.blade.php
@@ -32,7 +32,30 @@
                                     <option value="internet" {{ old('type', $resource->type) == 'internet' ? 'selected' : '' }}>🌏 Internet</option>
                                 </select>
                             </div>
+                        </div> 
+                        <div class="form-group">
+                            <label class="control-label col-sm-2" for="name">Report starts:</label>
+                            <div class="col-sm-10">
+                                <div class="input-group clockpicker">
+                                <input type="text" name="resource_starts" class="form-control" value="{{ old('resource_starts',$resource->resource_starts) }}">
+                                <span class="input-group-addon">
+                                    <span class="glyphicon glyphicon-time"></span>
+                                </span>
+                            </div>
+                            </div>
                         </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2" for="name">Report ends:</label>
+                            <div class="col-sm-10">
+                                <div class="input-group clockpicker">
+                                <input type="text" name="resource_ends" class="form-control" value="{{old('resource_ends',$resource->resource_ends)}}">
+                                <span class="input-group-addon">
+                                    <span class="glyphicon glyphicon-time"></span>
+                                </span>
+                            </div>
+                            </div>
+                        </div>
+
                     </div>
                     <div class="panel-footer clearfix">
                         <button class="btn btn-md btn-primary pull-right" type="submit">Update Resource</button>


### PR DESCRIPTION
Added extra fields on the /create and /edit pages. Now users can now specify a start time and end time per resource.  Resource reports will be generated between these time specified. If the start and end time are not specified, a 24hr report will be generated. 