### PR TITLE
Users can choose whether or not to exclude  weekends from resource records

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -101,7 +101,7 @@ class ResourceController extends Controller
      */
     public function store(CreateRequest $request)
     {
-        Resource::create($request->only(['name', 'type','resource_starts','resource_ends']));
+        Resource::create($request->only(['name', 'type','resource_starts','resource_ends','exclude_weekends']));
 
         return redirect(route('resources.index'))->withSuccess('Resource created!');
     }
@@ -126,7 +126,7 @@ class ResourceController extends Controller
      */
     public function update(UpdateRequest $request, Resource $resource)
     {
-        $resource->update($request->only('name', 'type','resource_starts','resource_ends'));
+        $resource->update($request->only('name', 'type','resource_starts','resource_ends','exclude_weekends'));
 
         return redirect(route('resources.show', $resource->id))->withSuccess('Updated successfully!');
     }

--- a/app/Resource.php
+++ b/app/Resource.php
@@ -18,7 +18,7 @@ class Resource extends Model {
     /**
      * {@inheritDoc}
      */
-    protected $fillable = ['name', 'type','resource_starts','resource_ends'];
+    protected $fillable = ['name', 'type','resource_starts','resource_ends','exclude_weekends'];
 
     /**
      * Get resource with records from date range.
@@ -31,13 +31,23 @@ class Resource extends Model {
     {
         $resource_starts   = isset( $this->resource_starts) ?  $this->resource_starts : '00:00';
         $resource_ends     = isset( $this->resource_ends) ?  $this->resource_ends : '24:00';
-
-        return $this->whereId($this->id)->with(['records' => function ($record) use ($startDate, $endDate, $resource_starts, $resource_ends ) {
-            $record->whereBetween('created_at', [$startDate->toDateString(), $endDate->addDay(1)->toDateString()])
-                    ->whereRaw('TIME(created_at) >= ?', $resource_starts)
-                    ->whereRaw('TIME(created_at) <= ?', $resource_ends)
-                    ->orderBy('created_at', 'desc');
-        }])->first();      
+        if($this->exclude_weekends == 1){
+            return $this->whereId($this->id)->with(['records' => function ($record) use ($startDate, $endDate, $resource_starts, $resource_ends ) {
+                $record->whereBetween('created_at', [$startDate->toDateString(), $endDate->addDay(1)->toDateString()])
+                        ->whereRaw('TIME(created_at) >= ?', $resource_starts)
+                        ->whereRaw('TIME(created_at) <= ?', $resource_ends)
+                        ->whereRaw('WEEKDAY( DATE(created_at) ) < ?', 5)
+                        ->orderBy('created_at', 'desc');
+                }])->first();
+        }
+        else{
+            return $this->whereId($this->id)->with(['records' => function ($record) use ($startDate, $endDate, $resource_starts, $resource_ends ) {
+                $record->whereBetween('created_at', [$startDate->toDateString(), $endDate->addDay(1)->toDateString()])
+                        ->whereRaw('TIME(created_at) >= ?', $resource_starts)
+                        ->whereRaw('TIME(created_at) <= ?', $resource_ends)
+                        ->orderBy('created_at', 'desc');
+                }])->first();          
+        }
               
     }
 

--- a/database/migrations/2017_09_26_05183_exclude_weekends_on_resource_records.php
+++ b/database/migrations/2017_09_26_05183_exclude_weekends_on_resource_records.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ExcludeWeekendsOnResourceRecords extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('resources', function ($table) {
+            $table->boolean('exclude_weekends')->after('type')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('resources', function (Blueprint $table){
+            $table->dropColumn('exclude_weekends');
+        });
+    }
+}
+
+

--- a/resources/views/resources/create.blade.php
+++ b/resources/views/resources/create.blade.php
@@ -35,7 +35,7 @@
                             <label class="control-label col-sm-2" for="name">Report starts:</label>
                             <div class="col-sm-10">
                                 <div class="input-group clockpicker">
-                                <input type="text" name="resource_starts" class="form-control" value="{{ old('resource_starts') }}">
+                                <input type="text" name="resource_starts" class="form-control"  placeholder="e.g 09:00" value="{{ old('resource_starts') }}">
                                 <span class="input-group-addon">
                                     <span class="glyphicon glyphicon-time"></span>
                                 </span>
@@ -46,11 +46,20 @@
                             <label class="control-label col-sm-2" for="name">Report ends:</label>
                             <div class="col-sm-10">
                                 <div class="input-group clockpicker">
-                                <input type="text" name="resource_ends" class="form-control" value="{{old('resource_ends')}}">
+                                <input type="text" name="resource_ends" class="form-control" placeholder="e.g 17:30" value="{{old('resource_ends')}}">
                                 <span class="input-group-addon">
                                     <span class="glyphicon glyphicon-time"></span>
                                 </span>
                             </div>
+                            </div>
+                        </div>
+                         <div class="form-group">
+                            <label class="control-label col-sm-2" for="name">Exclude Weekends</label>
+                            <div class="col-sm-10">
+                                <select class="form-control" required name="exclude_weekends">
+                                    <option value="1" {{ old('exclude_weekends') == 1 ? 'selected' : '' }}> Yes</option>
+                                    <option value="0" {{ old('exclude_weekends') == 0 ? 'selected' : '' }}> No</option>
+                                </select>
                             </div>
                         </div>
                     </div>

--- a/resources/views/resources/edit.blade.php
+++ b/resources/views/resources/edit.blade.php
@@ -55,6 +55,15 @@
                             </div>
                             </div>
                         </div>
+                        <div class="form-group">
+                            <label class="control-label col-sm-2" for="name">Exclude Weekends</label>
+                            <div class="col-sm-10">
+                                <select class="form-control" required name="exclude_weekends">
+                                    <option value="1" {{ old('exclude_weekends', $resource->exclude_weekends) == 1 ? 'selected' : '' }}> Yes</option>
+                                    <option value="0" {{ old('exclude_weekends', $resource->exclude_weekends) == 0 ? 'selected' : '' }}> No</option>
+                                </select>
+                            </div>
+                        </div>
 
                     </div>
                     <div class="panel-footer clearfix">


### PR DESCRIPTION
On create/edit page, users can now specify if they want to include or exclude weekend records from a selected resource